### PR TITLE
Introduce canonical Gabby Grove URIs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,8 +27,10 @@ The specification in this document is compatible with `ssb-uri` while adding sup
 - **Canonical SSB URIs**
   - `ssb:message/sha256/<MSGID>`
   - `ssb:message/bendybutt-v1/<MSGID>`
+  - `ssb:message/gabbygrove-v1/<MSGID>`
   - `ssb:feed/ed25519/<FEEDID>`
   - `ssb:feed/bendybutt-v1/<FEEDID>`
+  - `ssb:feed/gabbygrove-v1/<FEEDID>`
   - `ssb:blob/sha256/<BLOBID>`
   - `ssb:address/multiserver?multiserverAddress=<MSADDR>`
   - `ssb:encryption-key/box2-dm-dh/<KEY>`
@@ -49,8 +51,10 @@ These SSB URIs are to be considered stable and universally acceptable by all SSB
 ```
 ssb:message/sha256/<MSGID>
 ssb:message/bendybutt-v1/<MSGID>
+ssb:message/gabbygrove-v1/<MSGID>
 ssb:feed/ed25519/<FEEDID>
 ssb:feed/bendybutt-v1/<FEEDID>
+ssb:feed/gabbygrove-v1/<FEEDID>
 ssb:blob/sha256/<BLOBID>
 ```
 
@@ -63,6 +67,7 @@ ssb:message/sha256/g3hPVPDEO1Aj_uPl0-J2NlhFB2bbFLIHlty-YuqFZ3w=
 ssb:message/bendybutt-v1/PR2-btDEO1AjXuPl0TJ2N_hFB2bbFLIHlty0VF1ncty=
 ssb:feed/ed25519/-oaWWDs8g73EZFUMfW37R_ULtFEjwKN_DczvdYihjbU=
 ssb:feed/bendybutt-v1/APaWWDs8g73EZFUMfW37RBULtFEjwKNbDczvdYiRXtA=
+ssb:feed/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=
 ssb:blob/sha256/sbBmsB7XWvmIzkBzreYcuzPpLtpeCMDIs6n_OJGSC1U=
 ```
 
@@ -169,7 +174,7 @@ queryVal -> [a-zA-Z0-9] ([^&]):*
 
 type -> "message" | "feed" | "blob" | "address" | "experimental" | "encryption-key" | "identity"
 
-alg -> "sha256" | "ed25519" | "multiserver" | "bendybutt-v1" | "box2-dm-dh" | "po-box"
+alg -> "sha256" | "ed25519" | "multiserver" | "bendybutt-v1" | "gabbygrove-v1" | "box2-dm-dh" | "po-box"
 
 value -> ([0-9a-zA-Z\-\_\=]):+
 ```


### PR DESCRIPTION
This PR specifies the following Gabby Grove URIs as canonical:

`ssb:message/gabbygrove-v1/<MSGID>`
`ssb:feed/gabbygrove-v1/<FEEDID>`

It also adds an example of a canonical Gabby Grove feed URI:

`ssb:feed/gabbygrove-v1/FY5OG311W4j_KPh8H9B2MZt4WSziy_p-ABkKERJdujQ=`

Relevant docs: [Gabby Grove for Go](https://pkg.go.dev/go.mindeco.de/ssb-gabbygrove)